### PR TITLE
Rd 1868/replace retryable gem

### DIFF
--- a/content_caching.gemspec
+++ b/content_caching.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'right_http_connection', '~> 1.4'
 
   spec.add_dependency 's3', '~> 0.3'
-  spec.add_dependency 'retryable_block', '0.0.1'
+  spec.add_dependency 'retryable', '~> 3.0.0'
 end

--- a/lib/content_caching/adapters/aws.rb
+++ b/lib/content_caching/adapters/aws.rb
@@ -1,5 +1,4 @@
 require 's3'
-require 'retryable_block'
 
 module ContentCaching
   module Adapter
@@ -15,7 +14,7 @@ module ContentCaching
       end
 
       def store document_path, content
-        retryable(3) do
+        Retryable.retryable(tries: 3) do
           content.rewind if content.respond_to?(:rewind)
           new_object = bucket.objects.build document_path
           new_object.content = content
@@ -28,7 +27,7 @@ module ContentCaching
       end
 
       def delete document_path
-        retryable(3) do
+        Retryable.retryable(tries: 3) do
           bucket.object(document_path).destroy
         end
       end

--- a/lib/content_caching/version.rb
+++ b/lib/content_caching/version.rb
@@ -1,3 +1,3 @@
 module ContentCaching
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
get rid of our patched version in favor of maintained gem retryable

JIRA : https://finalcad.atlassian.net/browse/RD-1868

see https://github.com/FinalCAD/finalcloud/pull/7217 for more details