### PR TITLE
RD-2396: Replacing 's3' gem with 'aws-sdk-s3'

### DIFF
--- a/content_caching.gemspec
+++ b/content_caching.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr',     '~> 2.9'
   spec.add_development_dependency 'right_http_connection', '~> 1.4'
 
-  spec.add_dependency 's3', '~> 0.3'
+  spec.add_dependency 'aws-sdk-s3', '~> 1'
   spec.add_dependency 'retryable', '~> 3.0.0'
 end

--- a/lib/content_caching/adapters/aws.rb
+++ b/lib/content_caching/adapters/aws.rb
@@ -1,4 +1,4 @@
-require 's3'
+require 'aws-sdk-s3'
 
 module ContentCaching
   module Adapter
@@ -33,16 +33,19 @@ module ContentCaching
       private
 
       def service
-        @service ||= S3::Service.new(
-          :access_key_id => self.options[:aws_access_key_id],
-          :secret_access_key => self.options[:aws_secret_access_key],
-          :use_ssl => true,
-          :use_vhost => true
+        @service ||= ::Aws::S3::Resource.new(
+          credentials: aws_credentials,
+          region: self.options[:region]
         )
       end
 
       def bucket
         @bucket ||= service.bucket(self.options[:directory])
+      end
+
+      def aws_credentials
+        ::Aws::Credentials.new(self.options[:aws_access_key_id],
+                               self.options[:aws_secret_access_key])
       end
     end
   end

--- a/lib/content_caching/version.rb
+++ b/lib/content_caching/version.rb
@@ -1,3 +1,3 @@
 module ContentCaching
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
To address AWS::S3::PermanentRedirect error when trying to access a non default
region - bucket.

Ref: https://stackoverflow.com/questions/26533245/the-authorization-mechanism-you-have-provided-is-not-supported-please-use-aws4?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa