### PR TITLE
Delete API call changes post aws-sdk-s3 gem migration changes

### DIFF
--- a/lib/content_caching/adapters/aws.rb
+++ b/lib/content_caching/adapters/aws.rb
@@ -25,7 +25,7 @@ module ContentCaching
 
       def delete document_path
         Retryable.retryable(tries: 3) do
-          bucket.object(document_path).destroy
+          bucket.object(document_path).delete
         end
       end
 

--- a/lib/content_caching/version.rb
+++ b/lib/content_caching/version.rb
@@ -1,3 +1,3 @@
 module ContentCaching
-  VERSION = '0.3.4'
+  VERSION = '0.3.5'
 end


### PR DESCRIPTION
Aws::S3::Object : Delete API does not support the `destroy` key.
Changing `destroy` to `delete`.

Airbrake link: [link](https://finalcad.airbrake.io/projects/173411/groups/2191910004575318985?tab=notice-detail)